### PR TITLE
fix(footer): remove dead "Examples" link leading to 404 page

### DIFF
--- a/index.html
+++ b/index.html
@@ -706,7 +706,6 @@
                 <div class="mobile-center">
                     <h4 class="text-lg md:text-xl font-bold mb-4">Resources</h4>
                     <ul class="space-y-2 text-orange-200 text-sm md:text-base">
-                        <li><a href="https://github.com/NomenAK/SuperClaude/tree/master/examples" target="_blank" rel="noopener" class="hover:text-white transition-colors">Examples</a></li>
                         <li><a href="https://github.com/NomenAK/SuperClaude/releases" target="_blank" rel="noopener" class="hover:text-white transition-colors">Changelog</a></li>
                         <li><a href="https://github.com/NomenAK/SuperClaude/projects" target="_blank" rel="noopener" class="hover:text-white transition-colors">Roadmap</a></li>
                         <li><a href="https://opensource.org/licenses/MIT" target="_blank" rel="noopener" class="hover:text-white transition-colors">License</a></li>


### PR DESCRIPTION
This PR removes the "Examples" link from the website footer because it currently points to a non-existent GitHub page that returns a 404 error.

Closes #4 