### PR TITLE
fix(frontend): Remove overflow-hidden from GradientText component

### DIFF
--- a/src/components/ui/gradient-text.js
+++ b/src/components/ui/gradient-text.js
@@ -19,7 +19,7 @@ export function GradientText({
       className={cn(
         "relative mx-auto flex max-w-fit flex-row items-center justify-center",
         "rounded-[1.25rem] font-medium backdrop-blur transition-shadow duration-500",
-        "overflow-hidden cursor-pointer",
+        "cursor-pointer",
         className
       )}
       {...props}


### PR DESCRIPTION
The `overflow-hidden` class on the container of the `GradientText` component was causing the text to be clipped at the beginning and end of lines.

This commit removes the `overflow-hidden` class to fix the clipping issue and ensure the gradient text is fully visible.