### PR TITLE
Add automatic anchor links to documentation headings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-router-dom": "^7.8.1",
         "react-router-hash-link": "^2.4.3",
         "react-scripts": "5.0.1",
+        "rehype-autolink-headings": "^7.1.0",
         "rehype-raw": "^7.0.0",
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.1",
@@ -9137,6 +9138,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-parse-selector": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
@@ -15789,6 +15803,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/rehype-autolink-headings": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-7.1.0.tgz",
+      "integrity": "sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rehype-raw": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-router-dom": "^7.8.1",
     "react-router-hash-link": "^2.4.3",
     "react-scripts": "5.0.1",
+    "rehype-autolink-headings": "^7.1.0",
     "rehype-raw": "^7.0.0",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=JetBrains+Mono:wght@400;700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=JetBrains+Mono:wght@400;700&display=swap");
 
 @tailwind base;
 @tailwind components;
@@ -19,7 +19,6 @@
     --muted-foreground: #6b7280;
     --gradient-start: #3b82f6;
     --gradient-end: #8b5cf6;
-
   }
 
   .dark {
@@ -36,7 +35,6 @@
     --muted-foreground: #94a3b8;
     --gradient-start: #1e3a8a;
     --gradient-end: #5b21b6;
-
   }
 
   body {
@@ -44,17 +42,35 @@
     min-height: 100vh;
   }
 
-  h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     @apply font-bold text-foreground;
+    scroll-margin-top: 5rem;
   }
 
-  h1 { @apply text-4xl mb-6; }
-  h2 { @apply text-3xl mb-4; }
-  h3 { @apply text-2xl mb-3; }
-  h4 { @apply text-xl mb-2; }
-  h5 { @apply text-lg mb-2; }
+  h1 {
+    @apply text-4xl mb-6;
+  }
+  h2 {
+    @apply text-3xl mb-4;
+  }
+  h3 {
+    @apply text-2xl mb-3;
+  }
+  h4 {
+    @apply text-xl mb-2;
+  }
+  h5 {
+    @apply text-lg mb-2;
+  }
 
-  p { @apply mb-4 text-secondary-foreground; }
+  p {
+    @apply mb-4 text-secondary-foreground;
+  }
 
   a {
     @apply text-accent hover:underline;
@@ -88,9 +104,13 @@
   }
 
   .btn-neon::before {
-    content: '';
+    content: "";
     @apply absolute inset-0 -z-10 rounded-full;
-    background: linear-gradient(to right, var(--gradient-start), var(--gradient-end));
+    background: linear-gradient(
+      to right,
+      var(--gradient-start),
+      var(--gradient-end)
+    );
     transition: all 0.3s ease;
   }
 
@@ -117,5 +137,27 @@
     --bgColor-muted: var(--muted);
     --borderColor-default: var(--border);
     --borderColor-muted: var(--border);
+  }
+
+  /* Heading anchor link styles */
+  .anchor-link {
+    @apply ml-2 opacity-0 transition-opacity duration-200;
+    text-decoration: none;
+    font-weight: 400;
+  }
+
+  h1:hover .anchor-link,
+  h2:hover .anchor-link,
+  h3:hover .anchor-link,
+  h4:hover .anchor-link,
+  h5:hover .anchor-link,
+  h6:hover .anchor-link,
+  .anchor-link:focus {
+    @apply opacity-100;
+  }
+
+  .anchor-icon {
+    @apply text-accent;
+    font-size: 0.85em;
   }
 }

--- a/src/pages/DocViewerPage.js
+++ b/src/pages/DocViewerPage.js
@@ -1,35 +1,37 @@
-import React, { useEffect, useContext } from 'react';
-import { useParams, Link } from 'react-router-dom';
-import { HashLink } from 'react-router-hash-link';
-import ReactMarkdown from 'react-markdown';
-import 'github-markdown-css/github-markdown.css';
-import remarkGfm from 'remark-gfm';
-import rehypeRaw from 'rehype-raw';
-import rehypeSlug from 'rehype-slug';
-import CodeBlock from '../components/CodeBlock';
-import NotFoundPage from './NotFoundPage';
-import { useSidebar } from '../context/SidebarContext';
-import { ThemeContext } from '../context/ThemeContext';
-import { useDocumentationLoader } from '../hooks/useDocumentationLoader';
-import { useScrollToHash } from '../hooks/useScrollToHash';
-import { useTouchGestures } from '../hooks/useTouchGestures';
-import { resolveMarkdownLink } from '../utils/linkResolver';
+import React, { useEffect, useContext } from "react";
+import { useParams, Link } from "react-router-dom";
+import { HashLink } from "react-router-hash-link";
+import ReactMarkdown from "react-markdown";
+import "github-markdown-css/github-markdown.css";
+import remarkGfm from "remark-gfm";
+import rehypeRaw from "rehype-raw";
+import rehypeSlug from "rehype-slug";
+import rehypeAutolinkHeadings from "rehype-autolink-headings";
+import CodeBlock from "../components/CodeBlock";
+import NotFoundPage from "./NotFoundPage";
+import { useSidebar } from "../context/SidebarContext";
+import { ThemeContext } from "../context/ThemeContext";
+import { useDocumentationLoader } from "../hooks/useDocumentationLoader";
+import { useScrollToHash } from "../hooks/useScrollToHash";
+import { useTouchGestures } from "../hooks/useTouchGestures";
+import { resolveMarkdownLink } from "../utils/linkResolver";
 
 function DocViewerPage() {
   const { category, file } = useParams();
   const { openSidebar } = useSidebar();
   const { theme } = useContext(ThemeContext);
-  
+
   // Custom hooks
-  const { markdown, doc, loading, error } = useDocumentationLoader(category, file);
+  const { markdown, doc, loading, error } = useDocumentationLoader(
+    category,
+    file
+  );
   const { scrollToHash } = useScrollToHash(markdown);
   useTouchGestures(openSidebar);
 
-
   useEffect(() => {
-    document.documentElement.setAttribute('data-color-mode', theme);
+    document.documentElement.setAttribute("data-color-mode", theme);
   }, [theme]);
-
 
   if (loading) {
     return (
@@ -52,13 +54,26 @@ function DocViewerPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
             <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-red-100 dark:bg-red-900/20 flex items-center justify-center">
-              <svg className="w-8 h-8 text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              <svg
+                className="w-8 h-8 text-red-600 dark:text-red-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
               </svg>
             </div>
-            <h1 className="text-2xl font-bold text-foreground mb-2">Failed to load documentation</h1>
+            <h1 className="text-2xl font-bold text-foreground mb-2">
+              Failed to load documentation
+            </h1>
             <p className="text-muted-foreground mb-6">
-              {error.message || 'An error occurred while loading the documentation.'}
+              {error.message ||
+                "An error occurred while loading the documentation."}
             </p>
             <button
               onClick={() => window.location.reload()}
@@ -83,54 +98,38 @@ function DocViewerPage() {
           <div
             className="markdown-body p-2 sm:p-6"
             data-theme={theme}
-            style={{ backgroundColor: 'transparent' }}
+            style={{ backgroundColor: "transparent" }}
           >
             <ReactMarkdown
               children={markdown}
               remarkPlugins={[remarkGfm]}
-              rehypePlugins={[rehypeRaw, rehypeSlug]} // Add rehypeSlug for automatic heading IDs
+              rehypePlugins={[
+                rehypeRaw,
+                rehypeSlug,
+                [
+                  rehypeAutolinkHeadings,
+                  {
+                    behavior: "append",
+                    properties: {
+                      className: ["anchor-link"],
+                      ariaLabel: "Link to this section",
+                    },
+                    content: {
+                      type: "element",
+                      tagName: "span",
+                      properties: { className: ["anchor-icon"] },
+                      children: [{ type: "text", value: "#" }],
+                    },
+                  },
+                ],
+              ]}
               components={{
-                // Add custom heading components to ensure IDs are generated
-                h1: ({ node, children, ...props }) => (
-                  <h1 {...props} id={props.id || children.toString().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')}>
-                    {children}
-                  </h1>
-                ),
-                h2: ({ node, children, ...props }) => (
-                  <h2 {...props} id={props.id || children.toString().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')}>
-                    {children}
-                  </h2>
-                ),
-                h3: ({ node, children, ...props }) => (
-                  <h3 {...props} id={props.id || children.toString().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')}>
-                    {children}
-                  </h3>
-                ),
-                h4: ({ node, children, ...props }) => (
-                  <h4 {...props} id={props.id || children.toString().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')}>
-                    {children}
-                  </h4>
-                ),
-                h5: ({ node, children, ...props }) => (
-                  <h5 {...props} id={props.id || children.toString().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')}>
-                    {children}
-                  </h5>
-                ),
-                h6: ({ node, children, ...props }) => (
-                  <h6 {...props} id={props.id || children.toString().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')}>
-                    {children}
-                  </h6>
-                ),
                 code({ node, inline, className, children, ...props }) {
-                  const match = /language-(\w+)/.exec(className || '');
+                  const match = /language-(\w+)/.exec(className || "");
                   if (!inline && match) {
                     const code = node.children[0].value;
                     return (
-                      <CodeBlock
-                        language={match[1]}
-                        value={code}
-                        {...props}
-                      />
+                      <CodeBlock language={match[1]} value={code} {...props} />
                     );
                   }
                   return (
@@ -143,7 +142,7 @@ function DocViewerPage() {
                   const { href } = props;
 
                   // 1. Handle internal anchor links with smooth scrolling
-                  if (href && href.startsWith('#')) {
+                  if (href && href.startsWith("#")) {
                     return (
                       <a
                         {...props}
@@ -151,9 +150,9 @@ function DocViewerPage() {
                           e.preventDefault();
                           scrollToHash(href);
                           // Update URL without triggering a page reload
-                          window.history.pushState(null, '', href);
+                          window.history.pushState(null, "", href);
                         }}
-                        style={{ cursor: 'pointer' }}
+                        style={{ cursor: "pointer" }}
                       >
                         {children}
                       </a>
@@ -161,18 +160,38 @@ function DocViewerPage() {
                   }
 
                   // 2. Handle links to other markdown documents
-                  const markdownLink = resolveMarkdownLink(href, category, file);
+                  const markdownLink = resolveMarkdownLink(
+                    href,
+                    category,
+                    file
+                  );
                   if (markdownLink) {
                     // Use HashLink for smooth scrolling if there's a hash
                     if (markdownLink.hash) {
-                      return <HashLink smooth to={`${markdownLink.to}#${markdownLink.hash}`} {...props}>{children}</HashLink>;
+                      return (
+                        <HashLink
+                          smooth
+                          to={`${markdownLink.to}#${markdownLink.hash}`}
+                          {...props}
+                        >
+                          {children}
+                        </HashLink>
+                      );
                     }
-                    return <Link to={markdownLink.to} {...props}>{children}</Link>;
+                    return (
+                      <Link to={markdownLink.to} {...props}>
+                        {children}
+                      </Link>
+                    );
                   }
 
                   // 3. Handle all other cases as external links
-                  return <a {...props} target="_blank" rel="noopener noreferrer">{children}</a>;
-                }
+                  return (
+                    <a {...props} target="_blank" rel="noopener noreferrer">
+                      {children}
+                    </a>
+                  );
+                },
               }}
             />
           </div>


### PR DESCRIPTION
This PR enhances the documentation reading experience by adding automatic anchor links to all headings, making it easy to share and navigate to specific sections within documentation pages.

## Changes
Dependencies: Added rehype-autolink-headings@^7.1.0 for automatic anchor link generation

## Implementation
- Added smooth hover animations - anchor links fade in when hovering over
headings
- Implemented scroll-margin-top: 5rem on all headings to account for fixed
header offset (64px + 16px margin)
- Styled anchor links with accent color and subtle hover effects